### PR TITLE
Added scheduleState from smart plug

### DIFF
--- a/edimax.coffee
+++ b/edimax.coffee
@@ -80,6 +80,18 @@ module.exports = (env) ->
       return result
 
   class EdimaxSmartPlugSimple extends env.devices.PowerSwitch
+    # attributes
+    attributes:
+      state:
+        description: "Current State"
+        type: types.boolean
+        labels: ['on', 'off']
+      scheduleState:
+        description: "Current Schedule State"
+        type: types.boolean
+        labels: ['active', 'off']
+        acronym: 'Schedule'
+
     constructor: (@config, @plugin, lastState) ->
       @name = @config.name
       @id = @config.id
@@ -101,6 +113,7 @@ module.exports = (env) ->
       @powerMeteringSupported = false
       @recoverState = @config.recoverState
       @requestPromise = Promise.resolve()
+      @scheduleState = false
 
       super()
       @_state = lastState?.state?.value or false
@@ -143,6 +156,9 @@ module.exports = (env) ->
         else
           if values.state isnt @_state
             @_setState(values.state)
+          if values.scheduleState isnt @scheduleState
+            @scheduleState = values.scheduleState
+            @base.setAttribute('scheduleState', values.scheduleState)
 
         @base.resetLastError()
 
@@ -177,13 +193,19 @@ module.exports = (env) ->
         @base.rejectWithError Promise.reject, errorMessage
       )
 
+    getScheduleState: () ->
+      @smartPlug.getScheduleState(@options).then((schedState) =>
+        @base.setAttribute('scheduleState', schedState)
+        @scheduleState = schedState
+        return Promise.resolve @scheduleState
+      ).catch((error) =>
+        @base.error "Unable to get schedule state of device: " + error.toString()
+      )
+
+
   class EdimaxSmartPlug extends EdimaxSmartPlugSimple
     # attributes
     attributes:
-      state:
-        description: "Current State"
-        type: types.boolean
-        labels: ['on', 'off']
       energyToday:
         description: "Energy Usage Today"
         type: types.number


### PR DESCRIPTION
Hi Marcus,

added attribute to handle the current state of the schedule of the smartplug
"true" => "smart plug is scheduled ON", "false" => "smart plug is not scheduled or scheduled OFF"
This merge needs the parallel merge of edimax-smartplug.
Feel free to optimize my code ;-)

Regards Markus